### PR TITLE
Checks correctly routes auth strategy

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -42,7 +42,7 @@ internals.hawk = function (server, options) {
                 return h.unauthenticated(err, credentials ? { credentials, artifacts } : undefined);
             }
 
-            if (server.auth.lookup(request.route)) {
+            if (server.auth.lookup(request.route).payload) {
                 request.events.once('peek', (chunk) => {
 
                     const payloadHash = Crypto.initializePayloadHash(request.auth.credentials.algorithm, request.headers['content-type']);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -42,7 +42,7 @@ internals.hawk = function (server, options) {
                 return h.unauthenticated(err, credentials ? { credentials, artifacts } : undefined);
             }
 
-            if (request.route.settings.auth.payload) {
+            if (server.auth.lookup(request.route)) {
                 request.events.once('peek', (chunk) => {
 
                     const payloadHash = Crypto.initializePayloadHash(request.auth.credentials.algorithm, request.headers['content-type']);


### PR DESCRIPTION
When setting the default auth strategy hawk didn't respect that and crashed with: TypeError: Cannot read property 'payload' of undefined