### PR TITLE
fix(plugin): avoid error if auth is undefined

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -42,7 +42,7 @@ internals.hawk = function (server, options) {
                 return h.unauthenticated(err, credentials ? { credentials, artifacts } : undefined);
             }
 
-            if (request.route.settings.auth.payload) {
+            if (request.route.settings.auth && request.route.settings.auth.payload) {
                 request.events.once('peek', (chunk) => {
 
                     const payloadHash = Crypto.initializePayloadHash(request.auth.credentials.algorithm, request.headers['content-type']);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -83,6 +83,30 @@ describe('Plugin', () => {
             expect(res.result).to.equal('Success');
         });
 
+        it('calls through to handler on successful auth (via default strategy)', async () => {
+
+            const server = Hapi.server();
+            await server.register(Hawk);
+
+            server.auth.strategy('default', 'hawk', { getCredentialsFunc });
+            server.auth.default('default');
+
+            server.route({
+                method: 'POST',
+                path: '/hawk',
+                handler: function (request, h) {
+
+                    return 'Success';
+                }
+            });
+
+            const request = { method: 'POST', url: 'http://example.com:8080/hawk', headers: { authorization: hawkHeader('john', '/hawk').header } };
+            const res = await server.inject(request);
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('Success');
+        });
+
         it('calls through to handler on failed optional auth', async () => {
 
             const server = Hapi.server();


### PR DESCRIPTION
I'm getting an error when using a default strategy:
`Cannot read property 'payload' of undefined`
in the case where no **auth** object is defined in route options because a default strategy is declared

Searching for a solution, i found that [Stackoverflow question](https://stackoverflow.com/questions/57055801/hawk-authentication-error-with-hapi-hawk) related to the same error.

So i just changed the particular line.